### PR TITLE
TryLookup renamed to TryResolve

### DIFF
--- a/ENBLightPatcher/ENBLightPatcher.csproj
+++ b/ENBLightPatcher/ENBLightPatcher.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Mutagen.Bethesda" Version="0.20.0" />
-        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.10.15" />
+        <PackageReference Include="Mutagen.Bethesda" Version="0.22.1" />
+        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.12.1" />
     </ItemGroup>
 
 </Project>

--- a/ENBLightPatcher/Program.cs
+++ b/ENBLightPatcher/Program.cs
@@ -43,7 +43,7 @@ namespace ENBLightPatcher
                 if (placedObject.EditorID != null)
 
                 if (placedObject.LightData == null) continue;
-                state.LinkCache.TryLookup<ILightGetter>(placedObject.Base.FormKey ?? FormKey.Null, out var placedObjectBase);
+                placedObject.Base.TryResolve<ILightGetter>(state.LinkCache, out var placedObjectBase);
                 if (placedObjectBase == null || placedObjectBase.EditorID == null) continue;
                 if (placedObjectBase.EditorID.ContainsInsensitive("Candle") || placedObjectBase.EditorID.ContainsInsensitive("Torch") || placedObjectBase.EditorID.ContainsInsensitive("Camp"))
                 {


### PR DESCRIPTION
Also inverted the TryResolve to originate from the FormLink, as it now has the expected API to scope down to ILightGetter